### PR TITLE
Verify CSV Corruption

### DIFF
--- a/CognosDownload.ps1
+++ b/CognosDownload.ps1
@@ -117,7 +117,7 @@ Param(
         [switch]$ReportStudio
 )
 
-$version = [version]"21.02.09"
+$version = [version]"21.02.09.02"
 
 Add-Type -AssemblyName System.Web
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "21.02.09",
+  "version": "21.02.09.02",
   "description": "This update includes version checks, file encoding output, fixes for sending emails on errors, additional examples in CognosDefaults.ps1"
 }


### PR DESCRIPTION
On duplicate headers the CSV was somehow corrupted. This allows you to skip CSV verification process if you have duplicate headers.